### PR TITLE
Release v1.1.0: autoRestore option, CI integration, and test improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test -- --ci --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debouncing
 - Field inclusion/exclusion
 - Custom serializers
+
+## [1.1.0]
+
+### Added
+
+- `autoRestore` option to enable or disable automatic restoration of form data from storage.
+- Documentation updates for the `autoRestore` parameter in the README.
+
+### Improved
+
+- Minor performance optimizations for storage operations.
+- Enhanced error handling for storage adapter methods.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ interface UseFormStorageOptions<T extends FieldValues> {
   validate?: boolean; // Validate fields when restored
   serializer?: Record<Path<T>, Serializer<T, Path<T>>>; // Custom serializers
   autoSave?: boolean; // Enable/disable automatic saving
+  autoRestore?: boolean; // Enable/disable automatic restoration
 }
 ```
 
@@ -257,6 +258,23 @@ const { save } = useFormStorage('my-form', form, {
 // Manually save when needed
 const handleSave = () => {
   save();
+};
+```
+
+#### `autoRestore`
+
+- **Type**: `boolean`
+- **Default**: `true`
+- **Description**: Enable or disable automatic restoration of form data from storage. When disabled, you can manually restore data using the `restore` function returned by the hook.
+
+```typescript
+const { restore } = useFormStorage('my-form', form, {
+  autoRestore: false, // Disable automatic restoration
+});
+
+// Manually restore data when needed
+const handleRestore = () => {
+  restore();
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/react-hook-form-storage.svg)](https://www.npmjs.com/package/react-hook-form-storage)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/react-hook-form-storage.svg)](https://bundlephobia.com/package/react-hook-form-storage)
+![Tests](https://github.com/francogabriel92/react-hook-form-storage/actions/workflows/test.yml/badge.svg)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,12 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  collectCoverageFrom: ['src/**/*.(ts|tsx)', '!src/**/*.d.ts', '!src/index.ts'],
+  collectCoverageFrom: [
+    'src/**/*.(ts|tsx)',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+    '!src/tests/**',
+  ],
   coverageReporters: ['json', 'lcov', 'text', 'clover'],
   coverageDirectory: 'coverage',
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-form-storage",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A TypeScript library for React Hook Form persist functionality",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/tests/test-utils.ts
+++ b/src/tests/test-utils.ts
@@ -2,37 +2,40 @@ import { UseFormStorageAdapter } from '../types';
 
 export const createMockRemoteStore = (options?: {
   delayMs?: number;
-  shouldFail?: boolean;
+  shouldFailRestore?: boolean;
+  shouldFailSave?: boolean;
+  shouldFailClear?: boolean;
 }): UseFormStorageAdapter => {
   const memory: Record<string, string> = {};
   const delay = options?.delayMs ?? 100;
-  const shouldFail = options?.shouldFail ?? false;
-
-  const maybeFail = () => {
-    if (shouldFail) {
-      throw new Error('Remote store failed');
-    }
-  };
 
   const simulateNetwork = async <T>(fn: () => T): Promise<T> => {
     await new Promise((res) => setTimeout(res, delay));
-    maybeFail();
     return fn();
   };
 
   return {
     getItem: async (key) =>
       simulateNetwork(() => {
+        if (options?.shouldFailRestore) {
+          throw new Error('Simulated restore failure');
+        }
         return memory[key] ?? null;
       }),
 
     setItem: async (key, value) =>
       simulateNetwork(() => {
+        if (options?.shouldFailSave) {
+          throw new Error('Simulated save failure');
+        }
         memory[key] = value;
       }),
 
     removeItem: async (key) =>
       simulateNetwork(() => {
+        if (options?.shouldFailClear) {
+          throw new Error('Simulated clear failure');
+        }
         delete memory[key];
       }),
   };

--- a/src/tests/use-react-hook-form-storage.test.ts
+++ b/src/tests/use-react-hook-form-storage.test.ts
@@ -511,4 +511,30 @@ describe('useFormStorage', () => {
       );
     });
   });
+
+  it('Should handle non autoRestore scenarios', async () => {
+    localStorage.setItem(
+      STORAGE_TEST_KEY,
+      JSON.stringify(STORAGE_DEFAULT_VALUES)
+    );
+
+    const { getValues, formStorage } = await renderFormHook({
+      autoRestore: false,
+    });
+
+    // Assert that form was not initialized with localStorage values
+    expect(getValues('name')).toBe('');
+    expect(getValues('email')).toBe('');
+
+    // Restore values manually
+    act(async () => {
+      await formStorage.restore();
+    });
+
+    // Assert that form was restored with localStorage values
+    await waitFor(() => {
+      expect(getValues('name')).toBe(STORAGE_DEFAULT_VALUES.name);
+      expect(getValues('email')).toBe(STORAGE_DEFAULT_VALUES.email);
+    });
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ type UseFormStorageBaseOptions<T extends FieldValues> = {
     [P in Path<T>]?: Serializer<T, P>;
   };
   autoSave?: boolean;
+  autoRestore?: boolean;
 };
 
 type IncludedOptions<T extends FieldValues, K extends Path<T>[]> = {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,8 +4,7 @@
     "noEmit": false,
     "declaration": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "removeComments": true
+    "rootDir": "src"
   },
   "exclude": [
     "node_modules",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -13,6 +13,6 @@
     "**/*.test.tsx",
     "**/*.spec.ts",
     "**/*.spec.tsx",
-    "src/setupTests.ts"
+    "src/tests"
   ]
 }


### PR DESCRIPTION
# Version 1.1.0 Release

This pull request introduces version **1.1.0** of `react-hook-form-storage`, including a new feature, improved error handling, extended test coverage, and CI integration via GitHub Actions.

---

## What's New

###  Infrastructure
- Added **GitHub Actions workflow** `.github/workflows/test.yml`:
  - Runs tests on `push` to `main` and on every `pull_request`.
  - Uploads code coverage reports to **Codecov**.
  - Uses Node.js 22 and caches `npm` dependencies.

### Features
- Added `autoRestore` option to `useFormStorage`:
  - Enables or disables automatic restoration of form values from storage.
  - Defaults to `true` (enabled).
  - Fully documented in the README with usage examples.
  - Reflected in `UseFormStorageOptions` type definition.

### Testing
- Improved test coverage with new cases:
  - Handles malformed data on restore.
  - Gracefully manages errors on `setItem`, `removeItem`, and `getItem` via mock flags.
  - Supports manual restore flow when `autoRestore` is `false`.
- Enhanced `createMockRemoteStore` to simulate specific storage operation failures.

### Code Coverage & CI
- Added test status badge to the README.
- Excluded test files from coverage reports (`src/tests/**`) in `jest.config.js`.

### Internal Improvements
- Improved error handling.
- Refactored restore logic to be reusable for manual and automatic restoration.
- Removed `removeComments` from `tsconfig.build.json` to retain useful comments in type declarations.

---

## Documentation
- README updated with new `autoRestore` section and example.
- Manual `restore()` usage now included.

---

## Changelog
- Appended version `1.1.0` to `CHANGELOG.md` under `Added` and `Improved`.

---